### PR TITLE
feat&fix: new way to parse loot strings

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -11,7 +11,15 @@
     "OnHyperlinkEnter",
     "OnHyperlinkLeave",
     "TSM_API",
-    "SlashCmdList"
+    "SlashCmdList",
+        "LOOT_ITEM_SELF",
+        "LOOT_ITEM_SELF_MULTIPLE",
+        "LOOT_ITEM_PUSHED_SELF",
+        "LOOT_ITEM_PUSHED_SELF_MULTIPLE",
+        "LOOT_ITEM",
+        "LOOT_ITEM_MULTIPLE",
+        "LOOT_ITEM_PUSHED",
+        "LOOT_ITEM_PUSHED_MULTIPLE"
   ],
   "runtime.version": "Lua 5.1",
   "workspace.ignoreDir": [

--- a/data/MoneyLooterConsts.lua
+++ b/data/MoneyLooterConsts.lua
@@ -31,3 +31,20 @@ ML_EVENTS = {
     QuestLootReceived = "QUEST_LOOT_RECEIVED",
     AddonLoaded = "ADDON_LOADED",
 }
+-- Loot global patterns for self
+-- string.match returns itemLink, quantity || itemLink
+LOOT_PATTERNS_SELF = {
+    LOOT_ITEM_SELF:gsub("%%s", "(.+)"),                                      -- 1
+    LOOT_ITEM_SELF_MULTIPLE:gsub("%%s", "(.+)"):gsub("%%d", "(%%d+)"),       -- 2
+    LOOT_ITEM_PUSHED_SELF:gsub("%%s", "(.+)"),                               -- 1
+    LOOT_ITEM_PUSHED_SELF_MULTIPLE:gsub("%%s", "(.+)"):gsub("%%d", "(%%d+)") -- 2
+}
+
+-- Loot global patterns for others
+-- string.match returns playerName, itemLink, quantity || playerName, itemLink
+LOOT_PATTERNS = {
+    LOOT_ITEM:gsub("%%s", "(.+)"),                                      -- 2
+    LOOT_ITEM_MULTIPLE:gsub("%%s", "(.+)"):gsub("%%d", "(%%d+)"),       -- 3
+    LOOT_ITEM_PUSHED:gsub("%%s", "(.+)"),                               -- 2
+    LOOT_ITEM_PUSHED_MULTIPLE:gsub("%%s", "(.+)"):gsub("%%d", "(%%d+)") -- 3
+}


### PR DESCRIPTION
the old way was failing with some items, getting
wrong quantities
now using global patterns that the game uses to
create the loot strings, should parse correctly
the loot