### PR TITLE
Add manual loot exclusion from item value total

### DIFF
--- a/core/Core.lua
+++ b/core/Core.lua
@@ -228,7 +228,7 @@ local function ChatMsgLoot(_, _, lootString, _, _, _, playerName2)
 
     local totalPrice = price * quantity
     local itemID = Profiler.Measure("GetCachedItemInfoFromHyperlink", GetCachedItemInfoFromHyperlink, itemLink)
-    local i = LootedItem.new(itemID, itemLink, price, quantity)
+    local i = LootedItem.new(Data.NextLootEntryId(), itemID, itemLink, price, quantity)
     Data.InsertLootedItem(i)
     Data.InsertSummaryItem(i)
     Data.AddItemsMoney(totalPrice)

--- a/data/Data.lua
+++ b/data/Data.lua
@@ -40,6 +40,7 @@ Data.DB.prototype = {
     PriciestLink = "",
     ListLootedItems = CircularBuffer,
     Summary = Summary,
+    NextEntryId = 1,
     ----------------------------------------------
     Timer = 0,
     ----------------------------------------------
@@ -148,9 +149,29 @@ function Data.AddItemsMoney(money)
 end
 
 ---@param money integer
+function Data.SubItemsMoney(money)
+    if money ~= nil then
+        MoneyLooterDB.ItemsMoney = MoneyLooterDB.ItemsMoney - money
+        if MoneyLooterDB.ItemsMoney < 0 then
+            MoneyLooterDB.ItemsMoney = 0
+        end
+    end
+end
+
+---@param money integer
 function Data.AddTotalMoney(money)
     if money ~= nil then
         MoneyLooterDB.TotalMoney = MoneyLooterDB.TotalMoney + money
+    end
+end
+
+---@param money integer
+function Data.SubTotalMoney(money)
+    if money ~= nil then
+        MoneyLooterDB.TotalMoney = MoneyLooterDB.TotalMoney - money
+        if MoneyLooterDB.TotalMoney < 0 then
+            MoneyLooterDB.TotalMoney = 0
+        end
     end
 end
 
@@ -184,10 +205,54 @@ function Data.GetListLootedItems()
     return MoneyLooterDB.ListLootedItems
 end
 
+---@return integer
+function Data.NextLootEntryId()
+    local nextId = MoneyLooterDB.NextEntryId or 1
+    MoneyLooterDB.NextEntryId = nextId + 1
+    return nextId
+end
+
 ---@param lootedItem ML_Item
 function Data.InsertLootedItem(lootedItem)
     if lootedItem == nil then return end
     CBFunctions.Push(MoneyLooterDB.ListLootedItems, lootedItem)
+end
+
+local function RebuildSummaryAndDerivedData()
+    local itemsMoney = 0
+    local priciest = 0
+    local priciestLink = ""
+    local summary = {}
+
+    if MoneyLooterDB.ListLootedItems ~= nil then
+        CBFunctions.Iterate(MoneyLooterDB.ListLootedItems, function(lootedItem)
+            local itemTotal = lootedItem.value * lootedItem.quantity
+            itemsMoney = itemsMoney + itemTotal
+            summary = SMFunctions.InsertLootedItem(summary, lootedItem)
+
+            if lootedItem.value > priciest then
+                priciest = lootedItem.value
+                priciestLink = lootedItem.itemLink
+            end
+        end)
+    end
+
+    MoneyLooterDB.ItemsMoney = itemsMoney
+    MoneyLooterDB.TotalMoney = MoneyLooterDB.RawMoney + itemsMoney
+    MoneyLooterDB.Priciest = priciest
+    MoneyLooterDB.PriciestLink = priciestLink
+    MoneyLooterDB.Summary = summary
+end
+
+---@param lootedItem ML_Item
+---@return boolean
+function Data.RemoveLootedItem(lootedItem)
+    if lootedItem == nil or lootedItem.entryId == nil or MoneyLooterDB.ListLootedItems == nil then return false end
+    local removed = CBFunctions.RemoveItem(MoneyLooterDB.ListLootedItems, lootedItem)
+    if not removed then return false end
+
+    RebuildSummaryAndDerivedData()
+    return true
 end
 
 ---@return integer
@@ -398,6 +463,10 @@ function Data.GetSummary()
         MoneyLooterDB.Summary = {}
     end
     return MoneyLooterDB.Summary
+end
+
+function Data.RebuildDerivedData()
+    RebuildSummaryAndDerivedData()
 end
 
 ---@return boolean State_ForceVendorPrice

--- a/data/LootedItem.lua
+++ b/data/LootedItem.lua
@@ -5,13 +5,15 @@ local MoneyLooter = select(2, ...)
 local LootedItem = {}
 MoneyLooter.LootedItem = LootedItem
 
+---@param entryId integer|nil
 ---@param id integer
 ---@param itemLink string
 ---@param value integer
 ---@param quantity integer
 ---@return ML_Item
-function LootedItem.new(id, itemLink, value, quantity)
+function LootedItem.new(entryId, id, itemLink, value, quantity)
     local self = {}
+    self.entryId = entryId
     self.id = id
     self.itemLink = itemLink
     self.value = value
@@ -21,6 +23,7 @@ function LootedItem.new(id, itemLink, value, quantity)
 end
 
 ---@class ML_Item
+---@field entryId integer|nil
 ---@field id integer
 ---@field itemLink string
 ---@field value integer

--- a/data/Summary.lua
+++ b/data/Summary.lua
@@ -21,9 +21,13 @@ local pairs = pairs
 ---@param quantity integer
 ---@param value integer
 function SMFunctions.Insert(summary, itemLink, quantity, value)
+    if summary == nil then
+        summary = {}
+    end
+
     if summary[itemLink] == nil then
         summary[itemLink] = { [1] = quantity, [2] = value }
-        return
+        return summary
     end
     summary[itemLink][1] = summary[itemLink][1] + quantity
     summary[itemLink][2] = value

--- a/data/Summary.lua
+++ b/data/Summary.lua
@@ -44,7 +44,7 @@ function SMFunctions.GetTopItems(summary)
         local itemID = GetItemInfoFromHyperlink(itemLink)
         local quantity = item[1]
         local value = item[2]
-        local lootedItem = LootedItem.new(itemID, itemLink, value, quantity)
+        local lootedItem = LootedItem.new(nil, itemID, itemLink, value, quantity)
         table.insert(topItems, lootedItem)
     end
     table.sort(topItems, function(a, b)

--- a/locales/enUS.lua
+++ b/locales/enUS.lua
@@ -63,5 +63,6 @@ Locales.enUS = function()
     L["FORCE_VENDOR_PRICE_DISABLED"] = "|cFFd8de35Money Looter:|r Force vendor price disabled."
     L["TIME_ERROR"] =
     "|cFFd8de35Money Looter:|r The format is incorrect, it must be: 00h00m00s or any time combination (5m30s)"
+    L["REMOVE_CONFIRM"] = "Remove %s from session total?"
     return L
 end

--- a/locales/esES.lua
+++ b/locales/esES.lua
@@ -64,5 +64,6 @@ Locales.esES = function()
     L["FORCE_VENDOR_PRICE_DISABLED"] = "|cFFd8de35Money Looter:|r Forzar precio de venta de mercader deshabilitado."
     L["TIME_ERROR"] =
     "|cFFd8de35Money Looter:|r El formato es incorrecto, debe ser: 00h00m00s o cualquier combinación de tiempo (5m30s)"
+    L["REMOVE_CONFIRM"] = "¿Eliminar %s del total de la sesión?"
     return L
 end

--- a/locales/frFR.lua
+++ b/locales/frFR.lua
@@ -65,5 +65,6 @@ Locales.frFR = function()
     L["FORCE_VENDOR_PRICE_DISABLED"] = "|cFFd8de35Money Looter:|r Prix vendeur forcé désactivé."
     L["TIME_ERROR"] =
     "|cFFd8de35Money Looter:|r Le format est incorrect, il doit être: 00h00m00s ou n'importe quelle combinaison de temps (5m30s)"
+    L["REMOVE_CONFIRM"] = "Retirer %s du total de la session ?"
     return L
 end

--- a/locales/ruRU.lua
+++ b/locales/ruRU.lua
@@ -65,5 +65,6 @@ Locales.ruRU = function()
     L["FORCE_VENDOR_PRICE_DISABLED"] = "|cFFd8de35Money Looter:|r Принудительное отключение цены продавца."
     L["TIME_ERROR"] =
     "|cFFd8de35Money Looter:|r Формат неверен, он должен быть: 00h00m00s или любая комбинация времени (5m30s)."
+    L["REMOVE_CONFIRM"] = "Удалить %s из общей суммы сессии?"
     return L
 end

--- a/ui/UI.lua
+++ b/ui/UI.lua
@@ -6,6 +6,8 @@ local Constants = MoneyLooter.Constants
 local Utils = MoneyLooter.Utils
 ---@class ML_DataProvider
 local DataProvider = MoneyLooter.DataProvider
+---@class ML_Data
+local Data = MoneyLooter.Data
 
 ---@class ML_UI
 local UI = {}
@@ -30,11 +32,45 @@ function ML_ItemScrollMixin:OnClick()
     GameTooltip:Show()
 end
 
+function ML_ItemScrollMixin:OnRemoveClick()
+    local elementData = self:GetElementData()
+    if not elementData then return end
+    if Data.IsSummaryMode() or elementData.entryId == nil then return end
+
+    StaticPopupDialogs["MONEYLOOTER_REMOVE_ITEM"] = {
+        text = string.format(_G.MONEYLOOTER_L_REMOVE_CONFIRM, elementData.itemLink),
+        button1 = _G.YES,
+        button2 = _G.NO,
+        OnAccept = function()
+            self:RemoveItemFromSession(elementData)
+        end,
+        timeout = 0,
+        whileDead = true,
+        hideOnEscape = true,
+        preferredIndex = 3,
+    }
+    StaticPopup_Show("MONEYLOOTER_REMOVE_ITEM")
+end
+
+function ML_ItemScrollMixin:RemoveItemFromSession(elementData)
+    if not elementData then return end
+    if not Data.RemoveLootedItem(elementData) then return end
+
+    UI.MLMainFrame.ItemsGoldFS:SetText(Utils.GetCoinTextString(Data.GetItemsMoney()))
+    UI.MLMainFrame.GPHFS:SetText(Utils.GetCoinTextString(Data.CalcGPH()))
+    UI.MLMainFrame.PriciestFS:SetText(Utils.GetCoinTextString(Data.GetPriciest()))
+
+    if MoneyLooter.UIEvents and MoneyLooter.UIEvents.RefreshLootList then
+        MoneyLooter.UIEvents.RefreshLootList()
+    end
+end
+
 function ML_ItemScrollMixin:Init()
     ---@class ML_Item
     local elementData = self:GetElementData()
     self:SetRightText(elementData.value * elementData.quantity)
     self:SetLeftText(elementData.id, elementData.quantity, elementData.itemLink)
+    self.RemoveButton:SetShown(not Data.IsSummaryMode() and elementData.entryId ~= nil)
     self:TrimDataProvider()
 end
 

--- a/ui/UIEvents.lua
+++ b/ui/UIEvents.lua
@@ -18,6 +18,9 @@ local SMFunctions = MoneyLooter.SMFunctions
 ---@class ML_Profiler
 local Profiler = MoneyLooter.Profiler
 
+MoneyLooter.UIEvents = MoneyLooter.UIEvents or {}
+local UIEvents = MoneyLooter.UIEvents
+
 ----------------------------------------------------------------------------------------
 local GetAddOnMetadata = C_AddOns.GetAddOnMetadata or GetAddOnMetadata
 local GetMoney, CreateFrame = GetMoney, CreateFrame
@@ -72,6 +75,8 @@ local function PopulateLoot()
     Profiler.Stop("PopulateLoot")
 end
 
+UIEvents.RefreshLootList = PopulateLoot
+
 local function PopulateSummary()
     Profiler.Start("PopulateSummary")
     UI.MLMainFrame.ScrollBoxLoot.DataProvider:Flush()
@@ -81,6 +86,8 @@ local function PopulateSummary()
     Profiler.Stop("PopulateSummary.BulkInsert")
     Profiler.Stop("PopulateSummary")
 end
+
+UIEvents.RefreshSummaryList = PopulateSummary
 
 -----------------------------------------------------------------------------------------------
 function UpdateRawMoney()
@@ -365,6 +372,7 @@ function WatcherOnEvent(_, event, arg1)
     elseif event == Constants.Events.PlayerEnteringWorld and MoneyLooter.addonLoaded then
         Data.UpdateMLDB()
         Data.UpdateMLXDB()
+        Data.RebuildDerivedData()
         PopulateData()
         PopulateLoot()
         watcher:UnregisterEvent(Constants.Events.PlayerEnteringWorld)

--- a/ui/templates/ItemScroll.xml
+++ b/ui/templates/ItemScroll.xml
@@ -13,7 +13,7 @@
                 <FontString parentKey="RightLabel" inherits="GameFontHighlight" justifyH="RIGHT">
                     <Size y="20" />
                     <Anchors>
-                        <Anchor point="RIGHT" x="-5" />
+                        <Anchor point="RIGHT" x="-25" />
                     </Anchors>
                 </FontString>
                 <FontString parentKey="LeftLabel" inherits="GameFontHighlight" wordwrap="false"
@@ -27,6 +27,24 @@
                 </FontString>
             </Layer>
         </Layers>
+        <Frames>
+            <Button parentKey="RemoveButton">
+                <Size x="16" y="16"/>
+                <Anchors>
+                    <Anchor point="RIGHT" x="-5"/>
+                </Anchors>
+                <Layers>
+                    <Layer level="ARTWORK">
+                        <Texture setAllPoints="true" file="Interface\Buttons\UI-Panel-MinimizeButton-Up"/>
+                    </Layer>
+                </Layers>
+                <Scripts>
+                    <OnClick>
+                        self:GetParent():OnRemoveClick()
+                    </OnClick>
+                </Scripts>
+            </Button>
+        </Frames>
         <Scripts>
             <OnClick method="OnClick" />
         </Scripts>

--- a/utils/CircularBuffer.lua
+++ b/utils/CircularBuffer.lua
@@ -70,3 +70,42 @@ function CBFunctions.ToTable(buffer)
     end
     return result
 end
+
+---@param buffer ML_CircularBuffer
+---@param itemToRemove ML_Item
+function CBFunctions.RemoveItem(buffer, itemToRemove)
+    if not buffer or not itemToRemove or buffer.size == 0 then return end
+
+    local removed = false
+    local newBuffer = {}
+    local newSize = 0
+
+    local i = buffer.tail
+    for _ = 1, buffer.size do
+        local item = buffer.buffer[i]
+        if item then
+            local isSame = item.entryId ~= nil and item.entryId == itemToRemove.entryId
+
+            if isSame and not removed then
+                removed = true
+            else
+                newBuffer[newSize + 1] = item
+                newSize = newSize + 1
+            end
+        end
+        i = (i % buffer.capacity) + 1
+    end
+
+    for j = 1, newSize do
+        buffer.buffer[j] = newBuffer[j]
+    end
+    for j = newSize + 1, buffer.size do
+        buffer.buffer[j] = nil
+    end
+
+    buffer.size = newSize
+    buffer.head = newSize + 1
+    buffer.tail = 1
+
+    return removed
+end


### PR DESCRIPTION
- add a remove button on loot rows so a single item can be excluded from the item-value total
- keep removal scoped to individual loot entries instead of removing all identical items
- fix derived data rebuild after removal (summary, priciest item, totals)

## Why
Some low-quality items can have misleading auction values from pricing addons such as Auctionator or TSM.
This makes farm totals inaccurate, so the addon should let the user manually exclude outlier items from the session calculation.

## Notes
- I built this for my own use because I was tired of inflated totals from junk items priced weirdly on the AH. I figured others who care about accurate gold-per-hour tracking might appreciate being able to clean up their session totals too.