### PR TITLE
Fix error from battlepet links

### DIFF
--- a/core/Core.lua
+++ b/core/Core.lua
@@ -222,7 +222,7 @@ local function ChatMsgLoot(_, _, lootString, _, _, _, playerName2)
     if playerName ~= playerNameFromPN2 then return end
 
     local itemLink, quantity = GetLinkAndQuantityLoot(lootString)
-    if itemLink == nil then return end
+    if itemLink == nil or itemLink:find("battlepet:") then return end
 
     local price = Profiler.Measure("CalculatePrice", CalculatePrice, itemLink)
 


### PR DESCRIPTION
When I cage a pet (that is, moving it from the Pet Journal to the bags), MoneyLooter bugs out, since it isn’t prepared to parse battlepet links correctly:

<details>
<summary><code>3x bad argument #1</code></summary>

```denizenscript
3x bad argument #1 to '?' (Usage: local itemName, itemLink, itemQuality, itemLevel, itemMinLevel, itemType, itemSubType, itemStackCount, itemEquipLoc, itemTexture, sellPrice, classID, subclassID, bindTy
[MoneyLooter/core/Core.lua]:62: in function <MoneyLooter/core/Core.lua:59>
[tail call]: ?
[MoneyLooter/core/Core.lua]:154: in function <MoneyLooter/core/Core.lua:146>
[tail call]: ?
[MoneyLooter/core/Core.lua]:227: in function <MoneyLooter/core/Core.lua:216>
[tail call]: ?
[MoneyLooter/core/Core.lua]:280: in function <MoneyLooter/core/Core.lua:278>


Locals:
itemString=nil
info=nil
(*temporary)=<table>
itemInfoCache=<table>

```
</details>

So, let’s add a test for battlepet links to the existing nil check, and if it’s a pet just do nothing.

---

Wouldn’t it be better to handle pet links correctly, instead of ignoring them?

Probably not. 

- If we move a pet from the collection to the bags (caging), we don’t want to count it in MoneyLooter (it’s not new loot). 
- If the pet drops from a rare, *typically* it drops as pet *item*[^1], and these are not battlepet links, thus will be handled correctly by MoneyLooter.

[^1]: A *pet item* is the thing that has “Use: Teaches you how to summon and dismiss this companion.” in the tooltip. Using the item adds the pet to the collection.
